### PR TITLE
feat: move dotfiles and config from COPY to volume mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ docs/implementation-plans/
 
 # Binary
 devagent
+
+# UAT
+work/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # devagent
 
-Last verified: 2026-02-06
+Last verified: 2026-02-07
 
 ## Tech Stack
 - Language: Go 1.21+
@@ -29,7 +29,7 @@ Last verified: 2026-02-06
 - `internal/config/` - Configuration loading and validation
 - `internal/e2e/` - E2E test utilities
 - `config/` - Development config (config.yaml + templates/)
-- `config/templates/<name>/` - Template directories (docker-compose.yml.tmpl, devcontainer.json.tmpl, filter.py.tmpl, Dockerfile, Dockerfile.proxy)
+- `config/templates/<name>/` - Template directories (docker-compose.yml.tmpl, devcontainer.json.tmpl, Dockerfile, .gitignore, home/, proxy/)
 - `docs/` - Design plans and implementation phases
 - `docs/PODMAN.md` - Podman compatibility notes and workarounds
 

--- a/config/templates/basic/.gitignore
+++ b/config/templates/basic/.gitignore
@@ -1,0 +1,8 @@
+# Generated compose files
+docker-compose.yml
+
+# Proxy runtime data
+proxy/logs/
+
+# Proxy log files
+*.jsonl

--- a/config/templates/basic/Dockerfile
+++ b/config/templates/basic/Dockerfile
@@ -3,9 +3,6 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu
 # Install tmux for terminal session management
 RUN apt-get update && apt-get install -y tmux && rm -rf /var/lib/apt/lists/*
 
-# Copy home directory dotfiles
-COPY --chown=vscode:vscode home/vscode/ /home/vscode/
-
 # Install Claude Code for vscode user (not root)
 USER vscode
 RUN curl -fsSL https://claude.ai/install.sh | bash

--- a/config/templates/basic/Dockerfile.proxy
+++ b/config/templates/basic/Dockerfile.proxy
@@ -1,7 +1,0 @@
-FROM mitmproxy/mitmproxy:latest
-
-# Copy filter script into container
-COPY filter.py /home/mitmproxy/filter.py
-
-# Expose proxy port
-EXPOSE 8080

--- a/config/templates/basic/docker-compose.yml.tmpl
+++ b/config/templates/basic/docker-compose.yml.tmpl
@@ -23,7 +23,7 @@ services:
     volumes:
       - {{.ProjectPath}}:{{.WorkspaceFolder}}:cached
       - proxy-certs:/tmp/mitmproxy-certs:ro
-      - {{.ClaudeConfigDir}}:/home/vscode/.claude:cached
+      - {{.ProjectPath}}/.devcontainer/home/vscode:/home/vscode:cached
       - {{.ClaudeTokenPath}}:/run/secrets/claude-token:ro
     cap_drop:
       - NET_RAW
@@ -46,16 +46,14 @@ services:
     command: sleep infinity
 
   proxy:
-    build:
-      context: .
-      dockerfile: Dockerfile.proxy
+    image: mitmproxy/mitmproxy:latest
     container_name: devagent-{{.ProjectHash}}-proxy
     networks:
       - isolated
     volumes:
       - proxy-certs:/home/mitmproxy/.mitmproxy
-      - {{.ProjectPath}}/.devcontainer/proxy-logs:/var/log/proxy
-    command: ["mitmdump", "--listen-host", "0.0.0.0", "--listen-port", "{{.ProxyPort}}", "-s", "/home/mitmproxy/filter.py"]
+      - {{.ProjectPath}}/.devcontainer/proxy:/opt/devagent-proxy
+    command: ["mitmdump", "--listen-host", "0.0.0.0", "--listen-port", "{{.ProxyPort}}", "-s", "/opt/devagent-proxy/filter.py"]
     labels:
       devagent.managed: "true"
       devagent.sidecar_of: "{{.ProjectHash}}"

--- a/config/templates/basic/proxy/filter.py
+++ b/config/templates/basic/proxy/filter.py
@@ -63,7 +63,7 @@ def _get_domain_config(host: str) -> dict | None:
 
 
 # Log file path
-LOG_FILE_PATH = "/var/log/proxy/requests.jsonl"
+LOG_FILE_PATH = "/opt/devagent-proxy/logs/requests.jsonl"
 
 
 # Block GitHub PR merge API calls.

--- a/config/templates/go-project/.gitignore
+++ b/config/templates/go-project/.gitignore
@@ -1,0 +1,8 @@
+# Generated compose files
+docker-compose.yml
+
+# Proxy runtime data
+proxy/logs/
+
+# Proxy log files
+*.jsonl

--- a/config/templates/go-project/Dockerfile
+++ b/config/templates/go-project/Dockerfile
@@ -1,8 +1,5 @@
 FROM mcr.microsoft.com/devcontainers/go:1.25
 
-# Copy home directory dotfiles
-COPY --chown=vscode:vscode home/vscode/ /home/vscode/
-
 # Install Claude Code for vscode user (not root)
 USER vscode
 RUN curl -fsSL https://claude.ai/install.sh | bash

--- a/config/templates/go-project/Dockerfile.proxy
+++ b/config/templates/go-project/Dockerfile.proxy
@@ -1,7 +1,0 @@
-FROM mitmproxy/mitmproxy:latest
-
-# Copy filter script into container
-COPY filter.py /home/mitmproxy/filter.py
-
-# Expose proxy port
-EXPOSE 8080

--- a/config/templates/go-project/docker-compose.yml.tmpl
+++ b/config/templates/go-project/docker-compose.yml.tmpl
@@ -23,7 +23,7 @@ services:
     volumes:
       - {{.ProjectPath}}:{{.WorkspaceFolder}}:cached
       - proxy-certs:/tmp/mitmproxy-certs:ro
-      - {{.ClaudeConfigDir}}:/home/vscode/.claude:cached
+      - {{.ProjectPath}}/.devcontainer/home/vscode:/home/vscode:cached
       - {{.ClaudeTokenPath}}:/run/secrets/claude-token:ro
     cap_drop:
       - NET_RAW
@@ -46,16 +46,14 @@ services:
     command: sleep infinity
 
   proxy:
-    build:
-      context: .
-      dockerfile: Dockerfile.proxy
+    image: mitmproxy/mitmproxy:latest
     container_name: devagent-{{.ProjectHash}}-proxy
     networks:
       - isolated
     volumes:
       - proxy-certs:/home/mitmproxy/.mitmproxy
-      - {{.ProjectPath}}/.devcontainer/proxy-logs:/var/log/proxy
-    command: ["mitmdump", "--listen-host", "0.0.0.0", "--listen-port", "{{.ProxyPort}}", "-s", "/home/mitmproxy/filter.py"]
+      - {{.ProjectPath}}/.devcontainer/proxy:/opt/devagent-proxy
+    command: ["mitmdump", "--listen-host", "0.0.0.0", "--listen-port", "{{.ProxyPort}}", "-s", "/opt/devagent-proxy/filter.py"]
     labels:
       devagent.managed: "true"
       devagent.sidecar_of: "{{.ProjectHash}}"

--- a/config/templates/go-project/proxy/filter.py
+++ b/config/templates/go-project/proxy/filter.py
@@ -63,7 +63,7 @@ def _get_domain_config(host: str) -> dict | None:
 
 
 # Log file path
-LOG_FILE_PATH = "/var/log/proxy/requests.jsonl"
+LOG_FILE_PATH = "/opt/devagent-proxy/logs/requests.jsonl"
 
 
 # Block GitHub PR merge API calls.

--- a/docs/design-plans/2026-02-07-image-cleanup.md
+++ b/docs/design-plans/2026-02-07-image-cleanup.md
@@ -1,0 +1,168 @@
+# Image Cleanup Design
+
+## Summary
+
+The current Dockerfiles copy dotfiles and config files into images during build, which breaks Docker's layer cache every time you create a new container. This design moves those files to volume mounts instead, so Dockerfiles only contain `FROM` + `RUN` commands (installing packages and tools). With no project-specific content baked into images, Docker automatically hits its layer cache on subsequent builds using the same template.
+
+This change requires consolidating scattered config. Right now, each project gets a directory under `~/.local/share/devagent/claude-configs/<hash>/` for Claude settings, plus separate template files copied to `.devcontainer/`. This design collapses everything into `.devcontainer/` — dotfiles under `home/vscode/`, proxy config under `proxy/`. The proxy also switches from building a custom Dockerfile to using the upstream `mitmproxy/mitmproxy:latest` image directly, with filter.py mounted as a volume.
+
+## Definition of Done
+1. Dockerfiles have no COPY commands — only FROM + RUN commands for package/tool installation
+2. Dotfiles, .claude config, and filter.py are volume-mounted via compose instead of baked into images
+3. All config consolidated under `<project>/.devcontainer/` — no more scattered directories in `~/.local/share/devagent/claude-configs/`
+4. Dead code removed: `getContainerClaudeDir()`, `ensureClaudeDir()`, `copyClaudeTemplateFiles()`, `ClaudeConfigDir` field from TemplateData
+5. Docker layer caching makes subsequent project creation fast automatically (no custom caching mechanism)
+6. Proxy container uses a single volume mount for all host-side files (filter.py, logs, and any future needs)
+
+## Glossary
+
+- **Docker layer cache**: Docker's incremental build optimization that reuses unchanged layers from previous builds. When a Dockerfile has identical instructions up to a certain point, Docker skips rebuilding those layers.
+- **Volume mount**: Docker mechanism for mapping a host filesystem path into a container. Changes to mounted files don't require rebuilding the image.
+- **Devcontainer**: VS Code specification for containerized development environments, defined via `.devcontainer/devcontainer.json` and associated Dockerfiles or compose files.
+- **mitmproxy**: Open-source HTTPS proxy used here as a sidecar container for network isolation and domain allowlisting.
+- **Sidecar container**: A secondary container that runs alongside a primary container, providing supporting functionality (here, network filtering via mitmproxy).
+- **filter.py**: Python script for mitmproxy that defines traffic filtering rules (domain allowlists, blocklists, PR merge blocking).
+- **Go text/template**: Go's standard library templating engine, used to generate docker-compose.yml and devcontainer.json from `.tmpl` files with placeholder substitution.
+
+## Architecture
+
+Two changes that reinforce each other: simplify Dockerfiles by removing COPY commands, and consolidate scattered config into `.devcontainer/`.
+
+**Why they're connected:** The Dockerfiles currently COPY dotfiles and config into images. Removing COPY requires an alternative — volume mounts. Volume mounts work best when the source files are organized in one place. The config consolidation provides that organization.
+
+### Dockerfile simplification
+
+App Dockerfiles (`config/templates/basic/Dockerfile`, `config/templates/go-project/Dockerfile`) lose their `COPY` line. What remains:
+
+- `FROM` base image
+- `RUN` package installation (tmux for basic template)
+- `RUN curl claude.ai/install.sh | bash`
+
+With no COPY and no project-specific content, Docker's layer cache hits automatically on every subsequent build using the same template. No custom caching mechanism needed.
+
+`Dockerfile.proxy` is eliminated entirely. The proxy service switches from `build:` to `image: mitmproxy/mitmproxy:latest` in compose. filter.py is mounted as a volume instead of COPYed.
+
+### Volume mount changes
+
+**App container:** Replace the `ClaudeConfigDir` mount with a mount of `.devcontainer/home/vscode` → `/home/vscode`. This single mount covers dotfiles (`.bashrc`, `.zshrc`, `.tmux.conf`) and Claude config (`.claude/settings.json`). `WriteToProject()` already copies `template/home/` → `.devcontainer/home/`, so no new copy logic is needed.
+
+**Proxy container:** Replace the separate `proxy-logs` mount with a single mount of `.devcontainer/proxy/` → `/opt/devagent-proxy/`. This directory contains `filter.py` and `logs/`. The `proxy-certs` named volume stays unchanged — it's shared between app and proxy containers for mitmproxy CA cert trust.
+
+### Config consolidation
+
+Stop creating `~/.local/share/devagent/claude-configs/<hash>/` directories. All per-project config lives under `<project>/.devcontainer/`:
+
+```
+<project>/.devcontainer/
+├── docker-compose.yml          # Generated from template
+├── devcontainer.json           # Generated from template
+├── Dockerfile                  # Copied from template
+├── .gitignore                  # Copied from template
+├── home/vscode/                # Copied from template
+│   ├── .bashrc
+│   ├── .zshrc
+│   ├── .tmux.conf
+│   └── .claude/
+│       └── settings.json
+└── proxy/                      # Copied from template + runtime
+    ├── filter.py               # Copied from template
+    └── logs/                   # Created at runtime
+```
+
+### Template directory restructure
+
+Template directories gain a `proxy/` subdirectory and a `.gitignore`. Static files (filter.py, .gitignore) are no longer processed as Go templates — they're copied verbatim.
+
+```
+config/templates/basic/
+├── Dockerfile                  # Simplified (no COPY)
+├── devcontainer.json.tmpl      # Go template (unchanged)
+├── docker-compose.yml.tmpl     # Go template (modified mounts + proxy image)
+├── .gitignore                  # Static, copied verbatim
+├── home/vscode/                # Static, copied verbatim
+│   ├── .bashrc
+│   ├── .zshrc
+│   ├── .tmux.conf
+│   └── .claude/settings.json
+└── proxy/
+    └── filter.py               # Static, copied verbatim (was filter.py.tmpl)
+```
+
+## Existing patterns
+
+`WriteToProject()` in `devcontainer.go:278-322` already copies template directories to `.devcontainer/`. It copies `Dockerfile` and the `home/` directory. This design extends that pattern to also copy `proxy/` and `.gitignore`.
+
+`WriteComposeFiles()` in `devcontainer.go:324-369` writes generated compose files and creates the `proxy-logs/` directory. This design modifies it to create `proxy/logs/` instead and to stop writing `Dockerfile.proxy` and `filter.py` (both are now static template files copied by `WriteToProject()`).
+
+The `ComposeGenerator` in `compose.go` processes `.tmpl` files through Go's `text/template`. This design removes `processFilterTemplate()` and `loadDockerfileProxy()` / `generateDockerfileProxy()` since filter.py becomes a static copy and Dockerfile.proxy is eliminated.
+
+## Implementation phases
+
+<!-- START_PHASE_1 -->
+### Phase 1: Template restructure
+
+**Goal:** Reorganize template directories to the new layout. Rename filter.py.tmpl to filter.py, add proxy/ subdirectory, add .gitignore, simplify Dockerfiles.
+
+**Components:**
+- `config/templates/basic/Dockerfile` — remove COPY line
+- `config/templates/go-project/Dockerfile` — remove COPY line
+- `config/templates/basic/Dockerfile.proxy` — delete
+- `config/templates/go-project/Dockerfile.proxy` — delete
+- `config/templates/basic/filter.py.tmpl` — move to `proxy/filter.py`, remove `.tmpl` extension
+- `config/templates/go-project/filter.py.tmpl` — move to `proxy/filter.py`, remove `.tmpl` extension
+- `config/templates/basic/.gitignore` — new static file
+- `config/templates/go-project/.gitignore` — new static file
+
+**Dependencies:** None
+
+**Done when:** Template directories match the new layout. No functional changes yet — Go code still references old paths (will break until Phase 2).
+<!-- END_PHASE_1 -->
+
+<!-- START_PHASE_2 -->
+### Phase 2: Update compose template and TemplateData
+
+**Goal:** Modify docker-compose.yml.tmpl to use volume mounts instead of COPY, switch proxy to `image:` instead of `build:`, and update TemplateData.
+
+**Components:**
+- `config/templates/basic/docker-compose.yml.tmpl` — replace `ClaudeConfigDir` mount with `home/vscode` mount, replace proxy `build:` with `image:`, update proxy volumes to single `.devcontainer/proxy` mount, update mitmproxy command path
+- `config/templates/go-project/docker-compose.yml.tmpl` — same changes
+- `internal/container/compose.go` — remove `ClaudeConfigDir` from `TemplateData`, remove `processFilterTemplate()`, remove `loadDockerfileProxy()` / `generateDockerfileProxy()`, update `ComposeResult` to drop `DockerfileProxy` and `FilterScript` fields
+
+**Dependencies:** Phase 1
+
+**Done when:** Templates generate correct compose YAML with new mount paths. `TemplateData` has no `ClaudeConfigDir` field. Compose generation code no longer references filter.py or Dockerfile.proxy.
+<!-- END_PHASE_2 -->
+
+<!-- START_PHASE_3 -->
+### Phase 3: Update file writing and config consolidation
+
+**Goal:** Modify `WriteToProject()` to copy new static files (proxy/, .gitignore). Modify `WriteComposeFiles()` to stop writing Dockerfile.proxy and filter.py. Remove dead claude-config code.
+
+**Components:**
+- `internal/container/devcontainer.go` — update `WriteToProject()` to copy `proxy/` directory and `.gitignore` from template. Update `WriteComposeFiles()` to stop writing `Dockerfile.proxy` and `filter.py`, create `proxy/logs/` instead of `proxy-logs/`. Remove `getContainerClaudeDir()`, `ensureClaudeDir()`, `copyClaudeTemplateFiles()`, and all references to `~/.local/share/devagent/claude-configs/`.
+- `internal/container/devcontainer.go` — update `Generate()` to stop calling `ensureClaudeDir()` and `copyClaudeTemplateFiles()`
+
+**Dependencies:** Phase 2
+
+**Done when:** Container creation uses new file layout. No references to `claude-configs` directory remain. `WriteToProject()` copies proxy/ and .gitignore. `WriteComposeFiles()` only writes docker-compose.yml. Tests pass.
+<!-- END_PHASE_3 -->
+
+<!-- START_PHASE_4 -->
+### Phase 4: End-to-end verification
+
+**Goal:** Verify the full container creation flow works with the new layout.
+
+**Components:**
+- Existing E2E tests in `internal/e2e/` — verify they pass with changes
+- Manual verification: create a container, confirm dotfiles are mounted, confirm proxy has filter.py, confirm proxy logs work, confirm Claude config is present
+
+**Dependencies:** Phase 3
+
+**Done when:** E2E tests pass. A container created with the basic template has correct mounts, proxy filtering works, and Docker layer cache hits on second creation with same template.
+<!-- END_PHASE_4 -->
+
+## Additional considerations
+
+**Existing containers:** No backward compatibility needed. Existing containers created with the old layout will need to be recreated. This is acceptable per project requirements.
+
+**Proxy log path change:** The `.gitignore` in the template should ignore `proxy/logs/` and `*.jsonl`. The Go code that reads proxy logs (`internal/tui/` or `internal/container/`) may reference the old `proxy-logs/` path and will need updating if so.

--- a/internal/config/templates.go
+++ b/internal/config/templates.go
@@ -10,7 +10,7 @@ import (
 // Template represents a loaded devcontainer template.
 // Templates are discovered by scanning directories for docker-compose.yml.tmpl marker files.
 // All orchestration config (capabilities, resources, network allowlists) is hardcoded
-// directly in template files (docker-compose.yml.tmpl, filter.py.tmpl, devcontainer.json.tmpl).
+// directly in template files (docker-compose.yml.tmpl, proxy/filter.py, devcontainer.json.tmpl).
 type Template struct {
 	Name string // Template name (from directory name)
 	Path string // Absolute path to template directory

--- a/internal/container/CLAUDE.md
+++ b/internal/container/CLAUDE.md
@@ -1,13 +1,13 @@
 # Container Domain
 
-Last verified: 2026-02-06
+Last verified: 2026-02-07
 
 ## Purpose
-Orchestrates devcontainer lifecycle: creation via @devcontainers/cli, start/stop/destroy via Docker Compose, and tmux session management within containers. Manages per-container Claude Code configuration including auth token injection and persistent settings. Provides network isolation via mitmproxy sidecars with domain allowlisting and optional GitHub PR merge blocking. Integrates proxy log tailing for real-time HTTP request visibility in TUI.
+Orchestrates devcontainer lifecycle: creation via @devcontainers/cli, start/stop/destroy via Docker Compose, and tmux session management within containers. Provides network isolation via mitmproxy sidecars with domain allowlisting and optional GitHub PR merge blocking. Integrates proxy log tailing for real-time HTTP request visibility in TUI.
 
 ## Contracts
 - **Exposes**: `Manager`, `Container`, `Session`, `Sidecar`, `CreateOptions`, `ContainerState`, `RuntimeInterface`, `DevcontainerJSON`, `IsolationInfo`, `ProgressStep`, `ProgressCallback`, `ComposeGenerator`, `ComposeResult`, `ComposeOptions`, `TemplateData`, `GenerateResult`, `DevcontainerGenerator`, `DevcontainerCLI`, `ProcessDevcontainerTemplate`, `HashTruncLen`, `MountInfo`
-- **Guarantees**: Auto-detects Docker/Podman from config. Operations are idempotent (stop already-stopped is safe). Labels track devagent metadata. Claude config directories persist across container recreations. Sidecars are created before devcontainer and destroyed after. Proxy CA certs are auto-installed via postCreateCommand. Container creation reports progress via OnProgress callback. Isolation info can be queried from running containers. Compose mode generates docker-compose.yml with app + proxy services in isolated network. Proxy log reader started on container creation, stopped on destroy.
+- **Guarantees**: Auto-detects Docker/Podman from config. Operations are idempotent (stop already-stopped is safe). Labels track devagent metadata. Sidecars are created before devcontainer and destroyed after. Proxy CA certs are auto-installed via postCreateCommand. Container creation reports progress via OnProgress callback. Isolation info can be queried from running containers. Compose mode generates docker-compose.yml with app + proxy services in isolated network. Proxy log reader started on container creation, stopped on destroy.
 - **Expects**: Container runtime available. Valid config for Create operations. Refresh() called before List(). mitmproxy image available for network isolation. For compose mode: docker-compose or podman-compose available. LogManager must implement GetChannelSink() for proxy log integration.
 
 ## Dependencies
@@ -19,16 +19,14 @@ Orchestrates devcontainer lifecycle: creation via @devcontainers/cli, start/stop
 - RuntimeInterface abstraction: Enables mock testing without real containers; includes network ops (CreateNetwork, RemoveNetwork, RunContainer) and compose lifecycle ops (ComposeUp, ComposeStart, ComposeStop, ComposeDown)
 - Devcontainer CLI for creation: Handles complex setup (features, mounts, env); supports both image-based and dockerComposeFile modes
 - Compose orchestration: When CreateOptions.UseCompose is true, generates docker-compose.yml with app service (devcontainer) + proxy service (mitmproxy) in isolated network; uses devcontainer CLI's dockerComposeFile property
-- Compose file generation: ComposeGenerator processes docker-compose.yml.tmpl and filter.py.tmpl via processFilterTemplate(); Dockerfile.proxy is loaded as static file; filter.py.tmpl is embedded in template directories; DevcontainerGenerator.WriteAll() writes all files to .devcontainer/
+- Compose file generation: ComposeGenerator processes docker-compose.yml.tmpl via processComposeTemplate(); DevcontainerGenerator.WriteComposeFiles() writes docker-compose.yml and creates proxy/logs/ directory; DevcontainerGenerator.WriteToProject() copies template proxy/ and .gitignore to .devcontainer/
 - Labels for metadata: devagent.managed, devagent.project_path, devagent.template, devagent.remote_user, devagent.sidecar_of, devagent.sidecar_type
 - RemoteUser defaults to "vscode" per devcontainer spec; all exec operations use ExecAs with this user
-- Per-project Claude config: Each container gets a unique .claude directory (hashed by project path) mounted from ~/.local/share/devagent/claude-configs/
 - Auth token auto-provisioning: Checks for `{XDG_CONFIG_HOME}/claude/.devagent-claude-token` (or `~/.claude/.devagent-claude-token`), runs `claude setup-token` if missing (non-blocking on error)
 - Token injection via bind mount: Token file mounted read-only to `/run/secrets/claude-token`, shell profiles export CLAUDE_CODE_OAUTH_TOKEN from mounted file (not via containerEnv)
-- Template claude files: Copied from template's home/vscode/.claude/ to container's claude dir on creation (won't overwrite existing)
 - Sidecar architecture: Proxy sidecars use project path hash as ParentRef (not container ID) because sidecar is created before devcontainer exists
-- Network isolation via mitmproxy: Proxy command is static (no `--ignore-hosts` flag); filter.py.tmpl (from template) controls traffic with hardcoded allowlist and passthrough domains via the filter script's `load()` hook using `ctx.options.ignore_hosts`; CA cert mounted and installed in devcontainer via CertInstallCommand in postCreateCommand
-- GitHub PR merge blocking: When BLOCK_GITHUB_PR_MERGE enabled in filter.py.tmpl, filter script blocks PUT to /repos/.*/pulls/\d+/merge and POST /graphql with mergePullRequest
+- Network isolation via mitmproxy: Proxy uses mitmproxy/mitmproxy:latest image; filter.py (from template) controls traffic with hardcoded allowlist and passthrough domains via the filter script's `load()` hook using `ctx.options.ignore_hosts`; CA cert mounted and installed in devcontainer via CertInstallCommand in postCreateCommand
+- GitHub PR merge blocking: When BLOCK_GITHUB_PR_MERGE enabled in filter.py, filter script blocks PUT to /repos/.*/pulls/\d+/merge and POST /graphql with mergePullRequest
 - Proxy environment variables: http_proxy, https_proxy, and cert paths (REQUESTS_CA_BUNDLE, NODE_EXTRA_CA_CERTS, SSL_CERT_FILE) auto-injected when isolation enabled
 
 ## Invariants
@@ -38,7 +36,6 @@ Orchestrates devcontainer lifecycle: creation via @devcontainers/cli, start/stop
 - proxyLogCancels map protected by same mutex as containers
 - State transitions: created -> running <-> stopped -> (destroyed)
 - Manager methods are nil-safe for logger (NopLogger default)
-- Claude config directories are never deleted (persist user customizations)
 - Sidecar lifecycle: started before main container, stopped after main container
 - Network and proxy configs cleaned up only on Destroy (not Stop)
 - Proxy log reader lifecycle: started after CreateWithCompose, cancelled in DestroyWithCompose
@@ -46,9 +43,9 @@ Orchestrates devcontainer lifecycle: creation via @devcontainers/cli, start/stop
 ## Key Files
 - `manager.go` - Manager struct, compose-based lifecycle operations (CreateWithCompose, StartWithCompose, StopWithCompose, DestroyWithCompose), session management, sidecar lifecycle, GetContainerIsolationInfo()
 - `runtime.go` - RuntimeInterface impl for Docker/Podman CLI, ExecAs for user-specific commands, CreateNetwork, RemoveNetwork, RunContainer, InspectContainer(), GetIsolationInfo(), GetMounts(), ComposeUp/Start/Stop/Down
-- `compose.go` - ComposeGenerator with processFilterTemplate() and processComposeTemplate(), TemplateData (ProjectHash, ProjectPath, ProjectName, WorkspaceFolder, ClaudeConfigDir, TemplateName, ContainerName, CertInstallCommand, ProxyImage, ProxyPort, RemoteUser), ComposeResult, ComposeOptions; processes docker-compose.yml.tmpl and filter.py.tmpl for compose-based orchestration
-- `devcontainer.go` - DevcontainerGenerator, GenerateResult, DevcontainerCLI, ProcessDevcontainerTemplate; Claude config management, proxy env injection, CA cert mount; WriteComposeFiles(), WriteAll()
-- `proxy.go` - Mitmproxy utility functions: proxy config/cert directory management (GetProxyConfigDir, GetProxyCertDir, GetProxyCACertPath, ProxyCertExists), allowlist parsing from filter script (ReadAllowlistFromFilterScript, parseAllowlistFromScript), CleanupProxyConfigs
+- `compose.go` - ComposeGenerator with processComposeTemplate(), TemplateData (ProjectHash, ProjectPath, ProjectName, WorkspaceFolder, ClaudeTokenPath, TemplateName, ContainerName, CertInstallCommand, ProxyImage, ProxyPort, RemoteUser, ProxyLogPath), ComposeResult (ComposeYAML only), ComposeOptions; processes docker-compose.yml.tmpl for compose-based orchestration
+- `devcontainer.go` - DevcontainerGenerator, GenerateResult, DevcontainerCLI, ProcessDevcontainerTemplate; proxy env injection, CA cert mount; WriteToProject() copies proxy/, .gitignore, home/ from template; WriteComposeFiles() writes docker-compose.yml and creates proxy/logs/ directory; WriteAll() orchestrates WriteToProject + WriteComposeFiles
+- `proxy.go` - Mitmproxy utility functions: proxy cert directory management (GetProxyCertDir, GetProxyCACertPath, ProxyCertExists), allowlist parsing from filter script (ReadAllowlistFromFilterScript, parseAllowlistFromScript), CleanupProxyConfigs
 - `types.go` - Container, Session, Sidecar, CreateOptions (UseCompose flag), IsolationInfo, MountInfo (with JSON tags for external tool output), DevcontainerJSON (DockerComposeFile, Service, RemoteUser fields), BuildConfig, ProgressStep, ProgressCallback, HashTruncLen, state constants, label constants
 
 ## Gotchas
@@ -63,6 +60,6 @@ Orchestrates devcontainer lifecycle: creation via @devcontainers/cli, start/stop
 - Compose mode: workspace mount IS in docker-compose.yml (devcontainer CLI doesn't auto-mount in compose mode)
 - Compose mode requires templates to define isolation config (no hardcoded defaults)
 - Podman + dockerComposeFile: Known devcontainer CLI bug #863; see docs/PODMAN.md for workarounds
-- filter.py.tmpl is processed as a Go template via processFilterTemplate() but currently has no Go template placeholders (all config is hardcoded in the template)
+- filter.py is provided by the template and mounted at /opt/devagent-proxy/filter.py for the mitmproxy sidecar
 - Proxy log reader requires LogManager with GetChannelSink(); uses type assertion at runtime
-- Proxy log path is hardcoded: .devcontainer/proxy-logs/requests.jsonl
+- Proxy log path is created in .devcontainer/proxy/logs/ for JSONL request logging

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -423,7 +423,7 @@ func (m *Manager) CreateWithCompose(ctx context.Context, opts CreateOptions) (*C
 
 	// Start proxy log reader for this container
 	if m.logManager != nil {
-		proxyLogPath := filepath.Join(opts.ProjectPath, ".devcontainer", "proxy-logs", "requests.jsonl")
+		proxyLogPath := filepath.Join(opts.ProjectPath, ".devcontainer", "proxy", "logs", "requests.jsonl")
 		reader, err := logging.NewProxyLogReader(proxyLogPath, container.Name, m.logManager.(interface{ GetChannelSink() *logging.ChannelSink }).GetChannelSink())
 		if err != nil {
 			logger.Warn("failed to create proxy log reader", "error", err)
@@ -482,7 +482,7 @@ func (m *Manager) startMissingProxyLogReaders() {
 		}
 
 		// Start proxy log reader
-		proxyLogPath := filepath.Join(c.ProjectPath, ".devcontainer", "proxy-logs", "requests.jsonl")
+		proxyLogPath := filepath.Join(c.ProjectPath, ".devcontainer", "proxy", "logs", "requests.jsonl")
 		reader, err := logging.NewProxyLogReader(proxyLogPath, c.Name, sink.GetChannelSink())
 		if err != nil {
 			m.logger.Debug("failed to create proxy log reader", "container", c.Name, "error", err)

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -22,10 +22,13 @@ func testCreateContainer(t *testing.T, runtime string) {
 
 	cfg := TestConfig(runtime)
 	templates := TestTemplates()
-	projectDir := TestProject(t, "default")
+	projectDir := TestProject(t, "basic")
+
+	// Create logging manager for the TUI model
+	logMgr := TestLogManager(t)
 
 	// Create model and test runner
-	model := tui.NewModelWithTemplates(cfg, templates)
+	model := tui.NewModelWithTemplates(cfg, templates, logMgr)
 	runner := NewTUITestRunner(t, model)
 
 	// Initialize
@@ -85,10 +88,13 @@ func testStartStopContainer(t *testing.T, runtime string) {
 
 	cfg := TestConfig(runtime)
 	templates := TestTemplates()
-	projectDir := TestProject(t, "default")
+	projectDir := TestProject(t, "basic")
+
+	// Create logging manager for the TUI model
+	logMgr := TestLogManager(t)
 
 	// Create model and test runner
-	model := tui.NewModelWithTemplates(cfg, templates)
+	model := tui.NewModelWithTemplates(cfg, templates, logMgr)
 	runner := NewTUITestRunner(t, model)
 
 	// Initialize
@@ -100,9 +106,9 @@ func testStartStopContainer(t *testing.T, runtime string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	c, err := runner.Model().Manager().Create(ctx, container.CreateOptions{
+	c, err := runner.Model().Manager().CreateWithCompose(ctx, container.CreateOptions{
 		ProjectPath: projectDir,
-		Template:    "default",
+		Template:    "basic",
 		Name:        containerName,
 	})
 	if err != nil {
@@ -110,7 +116,9 @@ func testStartStopContainer(t *testing.T, runtime string) {
 	}
 
 	t.Cleanup(func() {
-		CleanupContainer(t, runtime, c.ID)
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		_ = runner.Model().Manager().DestroyWithCompose(cleanupCtx, c.ID)
 	})
 
 	// Refresh to see the container
@@ -169,10 +177,13 @@ func testDestroyContainer(t *testing.T, runtime string) {
 
 	cfg := TestConfig(runtime)
 	templates := TestTemplates()
-	projectDir := TestProject(t, "default")
+	projectDir := TestProject(t, "basic")
+
+	// Create logging manager for the TUI model
+	logMgr := TestLogManager(t)
 
 	// Create model and test runner
-	model := tui.NewModelWithTemplates(cfg, templates)
+	model := tui.NewModelWithTemplates(cfg, templates, logMgr)
 	runner := NewTUITestRunner(t, model)
 
 	// Initialize
@@ -184,9 +195,9 @@ func testDestroyContainer(t *testing.T, runtime string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	c, err := runner.Model().Manager().Create(ctx, container.CreateOptions{
+	c, err := runner.Model().Manager().CreateWithCompose(ctx, container.CreateOptions{
 		ProjectPath: projectDir,
-		Template:    "default",
+		Template:    "basic",
 		Name:        containerName,
 	})
 	if err != nil {
@@ -227,10 +238,13 @@ func testCreateTmuxSession(t *testing.T, runtime string) {
 
 	cfg := TestConfig(runtime)
 	templates := TestTemplates()
-	projectDir := TestProject(t, "default")
+	projectDir := TestProject(t, "basic")
+
+	// Create logging manager for the TUI model
+	logMgr := TestLogManager(t)
 
 	// Create model and test runner
-	model := tui.NewModelWithTemplates(cfg, templates)
+	model := tui.NewModelWithTemplates(cfg, templates, logMgr)
 	runner := NewTUITestRunner(t, model)
 
 	// Initialize
@@ -242,9 +256,9 @@ func testCreateTmuxSession(t *testing.T, runtime string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	c, err := runner.Model().Manager().Create(ctx, container.CreateOptions{
+	c, err := runner.Model().Manager().CreateWithCompose(ctx, container.CreateOptions{
 		ProjectPath: projectDir,
-		Template:    "default",
+		Template:    "basic",
 		Name:        containerName,
 	})
 	if err != nil {
@@ -309,10 +323,13 @@ func testKillTmuxSession(t *testing.T, runtime string) {
 
 	cfg := TestConfig(runtime)
 	templates := TestTemplates()
-	projectDir := TestProject(t, "default")
+	projectDir := TestProject(t, "basic")
+
+	// Create logging manager for the TUI model
+	logMgr := TestLogManager(t)
 
 	// Create model and test runner
-	model := tui.NewModelWithTemplates(cfg, templates)
+	model := tui.NewModelWithTemplates(cfg, templates, logMgr)
 	runner := NewTUITestRunner(t, model)
 
 	// Initialize
@@ -324,9 +341,9 @@ func testKillTmuxSession(t *testing.T, runtime string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	c, err := runner.Model().Manager().Create(ctx, container.CreateOptions{
+	c, err := runner.Model().Manager().CreateWithCompose(ctx, container.CreateOptions{
 		ProjectPath: projectDir,
-		Template:    "default",
+		Template:    "basic",
 		Name:        containerName,
 	})
 	if err != nil {
@@ -375,10 +392,13 @@ func testTmuxAttachCommand(t *testing.T, runtime string) {
 
 	cfg := TestConfig(runtime)
 	templates := TestTemplates()
-	projectDir := TestProject(t, "default")
+	projectDir := TestProject(t, "basic")
+
+	// Create logging manager for the TUI model
+	logMgr := TestLogManager(t)
 
 	// Create model and test runner
-	model := tui.NewModelWithTemplates(cfg, templates)
+	model := tui.NewModelWithTemplates(cfg, templates, logMgr)
 	runner := NewTUITestRunner(t, model)
 
 	// Initialize
@@ -390,9 +410,9 @@ func testTmuxAttachCommand(t *testing.T, runtime string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	c, err := runner.Model().Manager().Create(ctx, container.CreateOptions{
+	c, err := runner.Model().Manager().CreateWithCompose(ctx, container.CreateOptions{
 		ProjectPath: projectDir,
-		Template:    "default",
+		Template:    "basic",
 		Name:        containerName,
 	})
 	if err != nil {

--- a/internal/e2e/helpers.go
+++ b/internal/e2e/helpers.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"devagent/internal/config"
+	"devagent/internal/logging"
 	"devagent/internal/tui"
 )
 
@@ -95,6 +96,32 @@ func findProjectRoot() string {
 		}
 		dir = parent
 	}
+}
+
+// TestLogManager creates a logging manager for E2E tests with automatic cleanup.
+// The manager is configured with a temporary log file and will be automatically closed
+// via t.Cleanup when the test finishes.
+func TestLogManager(t *testing.T) *logging.Manager {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	logPath := tmpDir + "/test.log"
+	logMgr, err := logging.NewManager(logging.Config{
+		FilePath:       logPath,
+		MaxSizeMB:      1,
+		MaxBackups:     1,
+		MaxAgeDays:     1,
+		ChannelBufSize: 100,
+		Level:          "debug",
+	})
+	if err != nil {
+		t.Fatalf("Failed to create logging manager: %v", err)
+	}
+	t.Cleanup(func() {
+		logMgr.Close()
+	})
+
+	return logMgr
 }
 
 // CleanupContainer removes a container after test.


### PR DESCRIPTION
## Summary

- Simplify Dockerfiles to FROM+RUN only, eliminating COPY lines and Dockerfile.proxy entirely
- Move per-project config from baked-into-image (COPY) to volume mounts via docker-compose, enabling Docker layer cache hits on subsequent builds
- Consolidate proxy config under `.devcontainer/proxy/` with filter.py volume-mounted at `/opt/devagent-proxy/`
- Remove ~270 lines of dead code: claude-config management functions, Dockerfile.proxy generation, filter.py templating, proxy-configs directory management
- Update all unit tests, E2E tests, and documentation to reflect new architecture

## Test plan
- [x] `make build` passes
- [x] `make test` passes (6/6 packages)
- [x] `make test-race` passes (no data races)
- [x] `make lint` passes (0 issues)
- [x] `make test-e2e-docker` passes (4/4 E2E tests)
- [x] Zero stale references to removed code in .go files
- [x] Template directory structure matches design spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)