### PR TITLE
ci: drop nix preCheck HOME workaround; validate Windows build in CI

### DIFF
--- a/.github/workflows/ci_nix.yml
+++ b/.github/workflows/ci_nix.yml
@@ -25,3 +25,9 @@ jobs:
 
       - name: Build package
         run: nix build
+
+      # Also build the cross-compiled Windows package so its test phase runs in
+      # CI — it broke the v0.1.0 release because only `nix build` (native) ran
+      # here. Catches release-breaking issues before tagging.
+      - name: Build Windows package
+        run: nix build .#devagent-windows

--- a/flake.nix
+++ b/flake.nix
@@ -86,9 +86,6 @@
                   "-w"
                   "-X main.version=${version}"
                 ];
-                preCheck = ''
-                  export HOME="$(mktemp -d)"
-                '';
               };
               tsnsrvPkg = inputs.tsnsrv.packages.${pkgs.system}.tsnsrv;
             in
@@ -113,11 +110,6 @@
                 "-w"
                 "-X main.version=${version}"
               ];
-              # Match the native package: some tests touch $HOME (e.g. proxy cert
-              # dir), which is the unwritable /homeless-shelter in the sandbox.
-              preCheck = ''
-                export HOME="$(mktemp -d)"
-              '';
               postInstall = ''
                 mv $out/bin/devagent $out/bin/devagent.exe
               '';


### PR DESCRIPTION
Follow-up to the hermetic-test fix (`fc53b60`). Now that the web API tests pin `XDG_DATA_HOME` to a temp dir via a package `TestMain`, the nix `preCheck` (which pointed `HOME` at a writable temp to survive the sandbox's unwritable `/homeless-shelter`) is no longer load-bearing.

## Changes
- **flake.nix**: remove `preCheck` from both `devagent` and `devagent-windows`. This turns the nix build's test phase into a real guard against non-hermetic tests — if a test depends on a writable `$HOME`, the build now fails instead of being silently masked.
- **ci_nix.yml**: also `nix build .#devagent-windows`. Previously only the native `nix build` ran here, so the Windows cross-build's test phase (which broke the v0.1.0 release) had **no pre-tag CI coverage**. This PR's run exercises both.

## Why a PR (not direct to main)
This is the dry-run: the Linux CI sandbox sets `HOME=/homeless-shelter`, faithfully reproducing the release environment that my local macOS nix build can't. A green run here proves the module is hermetic without the workaround, for both the native and Windows builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)