### PR TITLE
fix(nix): pin Go 1.24 builder to a dedicated nixpkgs input

### DIFF
--- a/dev/flake-part.nix
+++ b/dev/flake-part.nix
@@ -15,8 +15,14 @@
   perSystem = {
     config,
     pkgs,
+    system,
     ...
-  }: {
+  }: let
+    # Pinned nixpkgs that still ships the Go 1.24 toolchain; mirrors the
+    # nixpkgs-go124 input in the top-level flake (nixpkgs-unstable HEAD has
+    # dropped Go 1.24). Keep this rev in sync with that input.
+    pkgsGo124 = inputs.nixpkgs-go124.legacyPackages.${system};
+  in {
     go-sri-hashes.devagent = {};
 
     devshells.default = {
@@ -29,9 +35,9 @@
         }
       ];
       packages = [
-        pkgs.go_1_24
+        pkgsGo124.go_1_24
         pkgs.gopls
-        (pkgs.delve.override { buildGoModule = pkgs.buildGo124Module; })
+        (pkgs.delve.override {buildGoModule = pkgsGo124.buildGo124Module;})
         pkgs.golangci-lint
         pkgs.lefthook
         inputs.tsnsrv.packages.${pkgs.system}.tsnsrv

--- a/flake.lock
+++ b/flake.lock
@@ -52,6 +52,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-go124": {
+      "locked": {
+        "lastModified": 1769421245,
+        "narHash": "sha256-m5QLKjpdhbDrhyrUbEm5Haq3lqE5Z6xh2tab5vTHUTo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b265bda51b42a2a85af0a543c3e57b778b01b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b265bda51b42a2a85af0a543c3e57b778b01b7d",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1765674936,
@@ -102,6 +118,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-go124": "nixpkgs-go124",
         "tsnsrv": "tsnsrv"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,14 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # nixpkgs-unstable HEAD has dropped the Go 1.24 builder (only buildGo123/
+    # 125/126Module remain), so we cannot build devagent against floating
+    # `nixpkgs`. Pin the last rev that still ships buildGo124Module/go_1_24 and
+    # source only the Go toolchain from it; everything else tracks `nixpkgs`.
+    # This must be a fixed rev, not the nixpkgs-unstable ref: a floating ref
+    # would re-resolve to a tip where the Go 1.24 builder is gone, breaking the
+    # build non-reproducibly.
+    nixpkgs-go124.url = "github:NixOS/nixpkgs/5b265bda51b42a2a85af0a543c3e57b778b01b7d";
     tsnsrv.url = "github:boinkor-net/tsnsrv";
   };
 
@@ -25,8 +33,13 @@
         config,
         lib,
         pkgs,
+        system,
         ...
       }: let
+        # Pinned nixpkgs that still provides the Go 1.24 builder; see the
+        # nixpkgs-go124 input comment above.
+        pkgsGo124 = inputs.nixpkgs-go124.legacyPackages.${system};
+
         version = let
           versionFile = ./. + "/.version";
         in
@@ -76,7 +89,7 @@
           {
             default = config.packages.devagent;
             devagent = let
-              unwrapped = pkgs.buildGo124Module {
+              unwrapped = pkgsGo124.buildGo124Module {
                 pname = "devagent";
                 inherit version;
                 vendorHash = builtins.readFile ./devagent.sri;
@@ -95,7 +108,7 @@
               };
           }
           // lib.optionalAttrs pkgs.stdenv.isLinux {
-            devagent-windows = pkgs.buildGo124Module {
+            devagent-windows = pkgsGo124.buildGo124Module {
               pname = "devagent-windows";
               inherit version;
               vendorHash = builtins.readFile ./devagent.sri;


### PR DESCRIPTION
## Problem

`flake.nix` sourced `pkgs.buildGo124Module` (and the dev shell sourced `go_1_24` / `buildGo124Module`) from the floating `nixpkgs.url = ".../nixpkgs-unstable"` input. nixpkgs-unstable HEAD has since **dropped the Go 1.24 toolchain** — only `buildGo123/125/126Module` remain.

The build worked today only by lock-file luck: `flake.lock` happened to pin `nixpkgs` to `5b265bda…` (2026-01-26), the last rev that still ships `buildGo124Module`. The next `nix flake update` would re-resolve `nixpkgs` to a tip without Go 1.24 and break the build non-reproducibly. This is the same breakage downstream packagers have had to work around by making the orchestrator follow a pinned nixpkgs.

## Fix

Add a dedicated `nixpkgs-go124` input pinned to a **fixed rev** (`5b265bda…`, not a branch ref — a floating ref would re-resolve and reintroduce the break) and source only the Go builder/toolchain from it. The main `nixpkgs` keeps floating for the frontend, `symlinkJoin`, formatter, etc.

- **flake.nix**: `devagent` (`unwrapped`) and `devagent-windows` use `pkgsGo124.buildGo124Module`
- **dev/flake-part.nix**: devshell uses `pkgsGo124.go_1_24` and the `delve` override's `buildGoModule`
- **flake.lock**: registers the new input (locked to the 2026-01-26 rev)

Cost is one extra nixpkgs in the closure — the same shape the bundled tsnsrv dep already has.

## Verification

- `nix eval .#devagent.name` and `.#devShells.aarch64-darwin.default.name` resolve (confirms `pkgsGo124.buildGo124Module` exists in the pinned rev)
- `nix flake check --no-build` → all checks passed
- Files formatted with `alejandra`

`devagent-windows` is Linux-only so it wasn't built locally (darwin host), but the edit is identical to the verified `devagent` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)