### PR TITLE
fix(tui): show predicted-container logs for unregistered worktrees

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -652,15 +652,20 @@ func (m *Model) setLogFilterFromContext() {
 		case item.IsWorktree():
 			// Worktree selected — filter to containers for this worktree path
 			names := m.containerNamesForPath(item.ProjectPath)
-			if len(names) > 0 {
-				m.logFilter = "scope"
-				m.logFilterNames = names
-				m.logFilterLabel = item.WorktreeName
-			} else {
-				m.logFilter = "scope"
-				m.logFilterNames = map[string]bool{} // empty = match nothing
-				m.logFilterLabel = item.WorktreeName
+			if len(names) == 0 {
+				// No registered container yet (e.g. build in-progress or failed).
+				// Predict the compose name so build/error logs are still visible.
+				var baseName string
+				if item.WorktreeName == "main" {
+					baseName = filepath.Base(item.ProjectPath)
+				} else {
+					baseName = filepath.Base(filepath.Dir(filepath.Dir(item.ProjectPath))) + "-" + item.WorktreeName
+				}
+				names = map[string]bool{container.SanitizeComposeName(baseName): true}
 			}
+			m.logFilter = "scope"
+			m.logFilterNames = names
+			m.logFilterLabel = item.WorktreeName
 		case item.IsProject():
 			// Project selected — filter to all containers under this project
 			names := m.containerNamesForProject(item.ProjectPath)

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -686,6 +686,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.logger.Error("worktree container start failed", "name", msg.name, "error", msg.err)
 			m.setError("Failed to start worktree container", msg.err)
+			m.setLogFilterFromContext()
 			return m, nil
 		}
 		m.logger.Info("worktree container started", "name", msg.name)


### PR DESCRIPTION
## Summary
- When a worktree has no registered container yet (build in progress or build failed), `setLogFilterFromContext` set an empty name set, so the log panel matched nothing and hid build/error logs.
- Now predicts the compose container name from the worktree path (mirroring the naming used at container creation) so build and error logs remain visible while a worktree has no live container.
- Refreshes the log filter after a worktree container start failure so the failure logs surface immediately instead of after the next selection change.

## Testing
- `go build ./internal/tui/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)