### PR TITLE
fix(templates): stream proxy responses to preserve SSE streaming

### DIFF
--- a/config/templates/basic/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/basic/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -189,6 +189,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:

--- a/config/templates/go-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/go-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -190,6 +190,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:

--- a/config/templates/python-fullstack/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/python-fullstack/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -197,6 +197,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:

--- a/config/templates/python-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/python-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -194,6 +194,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:


### PR DESCRIPTION
## Problem

The mitmproxy egress filter (`filter.py`) defeats the Anthropic API's SSE streaming. mitmproxy buffers the **entire** response body before forwarding any of it by default. The addon defined a `response()` hook but never set `flow.response.stream = True`, so:

1. The proxy read the whole event stream from Anthropic before sending the client a single byte — token-by-token streaming silently collapsed into one burst at the very end.
2. Anthropic's SSE ping keepalive events (whose entire purpose is keeping the socket warm during long generations) got buffered and became useless.
3. The proxy→client socket sat idle for the whole generation, tripping idle timeouts on long / large-context requests. Observed `/v1/messages` durations: p50 5.7s, p90 27s, **max 169s** — exactly the window where an idle connection gets killed.

Large request bodies compound it: mitmproxy also buffers the full request body before forwarding, adding latency and memory before the call even starts.

## Fix

- **`responseheaders` hook** sets `flow.response.stream = True` so chunks forward as they arrive and SSE keepalives reach the client. Safe globally — blocked requests get `flow.response` set earlier (`request`/`http_connect`) and never reach this hook, and `_log_request` only reads headers/status/timestamps (never the body), so it stays streaming-compatible.
- **`requestheaders` hook** streams large request bodies, scoped to `api.anthropic.com` only. GitHub is deliberately excluded because `_is_github_pr_merge` reads the GraphQL body in `request()`, which streaming would consume.

Applied to all four templates: `basic`, `python-project`, `python-fullstack`, `go-project`.

## Rollout

mitmproxy hot-reloads the script (per the compose mount comment), so existing containers pick this up without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)