### PR TITLE
fix(templates): stream proxy responses to preserve SSE streaming

### DIFF
--- a/config/templates/basic/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/basic/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -189,6 +189,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:

--- a/config/templates/go-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/go-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -190,6 +190,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:

--- a/config/templates/python-fullstack/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/python-fullstack/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -197,6 +197,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:

--- a/config/templates/python-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
+++ b/config/templates/python-project/.devcontainer/containers/proxy/opt/devagent-proxy/filter.py
@@ -194,6 +194,33 @@ class AllowlistFilter:
             ctx.log.error(f"request filter error, blocking: {e}")
             self._block(flow, "proxy filter error\n")
 
+    def requestheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream large request bodies through instead of buffering them.
+
+        Scoped to api.anthropic.com only: big-context requests otherwise get
+        fully buffered (latency + memory) before the call even starts. GitHub is
+        deliberately excluded because _is_github_pr_merge reads the GraphQL body
+        in the request() hook, which streaming would consume.
+        """
+        if flow.request.host.lower() == "api.anthropic.com":
+            flow.request.stream = True
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        """Stream response bodies through instead of buffering them.
+
+        mitmproxy buffers the whole response by default, which defeats the
+        Anthropic API's SSE streaming (text/event-stream): the client gets
+        nothing until generation finishes, so long / large-context requests look
+        like an idle hung connection and trip idle timeouts. Streaming forwards
+        chunks as they arrive and lets SSE ping keepalives reach the client.
+
+        Safe globally: blocked requests get flow.response set earlier (in
+        request/http_connect) and never reach this hook. _log_request only reads
+        headers/status/timestamps, never the body, so it stays streaming-compatible.
+        """
+        if flow.response is not None:
+            flow.response.stream = True
+
     def response(self, flow: http.HTTPFlow) -> None:
         """Log completed HTTP request/response to JSONL file."""
         if flow.response is None:


### PR DESCRIPTION
## Summary

mitmproxy buffers the full response body by default, which defeats the Anthropic API's SSE streaming. The `filter.py` addon defined a `response()` hook but never set `flow.response.stream = True`, so the proxy read the entire event stream from Anthropic before forwarding a single byte to the client. Token-by-token streaming collapsed into one burst at the end, and SSE ping keepalives were buffered into uselessness — leaving the proxy→client socket idle for the whole generation and tripping idle timeouts on long / large-context requests.

## Changes

- Add a `responseheaders` hook that sets `flow.response.stream = True` so chunks forward as they arrive. `_log_request` only reads headers/status/timestamps (never the body), so it stays streaming-compatible. Blocked requests get `flow.response` set earlier (`request`/`http_connect`) and never reach this hook, so streaming is safe globally.
- Add a `requestheaders` hook scoped to `api.anthropic.com` to stream large request bodies, avoiding the buffer/latency/memory hit before the call starts. GitHub is excluded because `_is_github_pr_merge` reads the GraphQL body in `request()`.
- Applied to all four templates (basic, python-project, python-fullstack, go-project). mitmproxy hot-reloads the script, so existing containers pick this up without a rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)